### PR TITLE
Fix bug in NCHG compute

### DIFF
--- a/src/libnchg/expected_values_impl.hpp
+++ b/src/libnchg/expected_values_impl.hpp
@@ -686,7 +686,7 @@ auto ExpectedValues<File>::deserialize_bin_masks(HighFive::File &f)
 
     auto mask1_ptr = std::make_shared<const std::vector<bool>>(std::move(mask1));
     auto mask2_ptr =
-        mask2.empty() ? mask1_ptr : std::make_shared<const std::vector<bool>>(std::move(mask2));
+        mask2.empty() ? mask1_ptr : std::make_shared<const std::vector<bool>>(mask2);
     buffer.emplace(std::make_pair(chrom1, chrom2), std::make_pair(mask1_ptr, mask2_ptr));
   }
 

--- a/src/libnchg/nchg_impl.hpp
+++ b/src/libnchg/nchg_impl.hpp
@@ -220,8 +220,8 @@ inline auto NCHG<File>::iterator::operator*() const -> const_reference {
 
   const auto exp = std::max(_exp->at(i1, i2), cutoff);
 
-  const auto delta = intra_matrix ? p.coords.bin2.start() - p.coords.bin1.start() : _min_delta;
-  if (delta < _min_delta || delta >= _max_delta) {
+  const auto delta = p.coords.bin2.start() - p.coords.bin1.start();
+  if (intra_matrix && (delta < _min_delta || delta >= _max_delta)) {
     _value = {p, exp, 1.0, 0.0, 0.0, 0.0};
     return _value;
   }

--- a/src/libnchg/observed_matrix_impl.hpp
+++ b/src/libnchg/observed_matrix_impl.hpp
@@ -35,7 +35,7 @@ inline auto ObservedMatrix<PixelIt>::compute_stats(
     const hictk::Chromosome &chrom2, const hictk::BinTable &bins,
     const std::vector<bool> &bin_mask1, const std::vector<bool> &bin_mask2,
     std::uint64_t min_delta_, std::uint64_t max_delta_) {
-  assert(min_delta_ < max_delta_);
+  assert(min_delta_ <= max_delta_);
   struct Result {
     std::shared_ptr<std::vector<std::uint64_t>> marginals1{
         std::make_shared<std::vector<std::uint64_t>>()};


### PR DESCRIPTION
Fix bug that would lead to empty parquet files when using multiprocessing and pre-computed expected values.