### PR TITLE
Change how the log ratio is computed

### DIFF
--- a/src/libnchg/nchg_impl.hpp
+++ b/src/libnchg/nchg_impl.hpp
@@ -387,7 +387,7 @@ inline auto NCHG<File>::compute(const hictk::GenomicInterval &range1,
   const auto odds_ratio = compute_odds_ratio(obs, static_cast<double>(obs_sum), N1, N2);
   const auto omega = intra_matrix ? compute_odds_ratio(exp, exp_sum, L1, L2) : 1;
 
-  const auto log_ratio = std::log2(odds_ratio) - std::log2(omega);
+  const auto log_ratio = std::log2(obs) - std::log2(exp);
 
   if ((L1 - exp) * (L2 - exp) <= cutoff) {
     return {p, exp, 1.0, log_ratio, odds_ratio, omega};


### PR DESCRIPTION
log2(obs/exp) is generally more useful than log2(odds_ratio/omega).
Going forward, NCHG will output the former rather than the latter.