### PR TITLE
Workaround CI timeouts when building arm64 Docker images

### DIFF
--- a/.github/workflows/build-dockerfile.yml
+++ b/.github/workflows/build-dockerfile.yml
@@ -166,10 +166,13 @@ jobs:
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
         with:
-          platforms: linux/amd64,linux/arm64
+          # TODO fixme: https://github.com/paulsengroup/NCHG/pull/51
+          # platforms: linux/amd64,linux/arm64
+          platforms: linux/amd64
 
+      # TODO fixme: https://github.com/paulsengroup/NCHG/pull/51
       - name: Set up QEMU
-        if: github.event_name != 'pull_request'
+        if: false #github.event_name != 'pull_request'
         uses: docker/setup-qemu-action@v3
         with:
           platforms: arm64
@@ -205,8 +208,9 @@ jobs:
       - name: Test Docker image (x86)
         run: utils/devel/test_docker_image.sh nchg:x86
 
+      # TODO fixme: https://github.com/paulsengroup/NCHG/pull/51
       - name: Build Docker image (arm64)
-        if: github.event_name != 'pull_request'
+        if: false #github.event_name != 'pull_request'
         uses: docker/build-push-action@v6
         with:
           context: ${{ github.workspace }}
@@ -240,7 +244,8 @@ jobs:
             type=registry,ref=${{ steps.build-args.outputs.CACHE_REGISTRY_X86 }}
             type=registry,ref=${{ steps.build-args.outputs.CACHE_REGISTRY_ARM64 }}
           tags: ${{ steps.meta.outputs.tags }}
-          platforms: linux/amd64,linux/arm64
+          # TODO fixme: https://github.com/paulsengroup/NCHG/pull/51
+          platforms: linux/amd64
           build-args: |
             C_COMPILER=${{ steps.build-args.outputs.C_COMPILER }}
             CXX_COMPILER=${{ steps.build-args.outputs.CXX_COMPILER }}

--- a/Dockerfile
+++ b/Dockerfile
@@ -42,6 +42,20 @@ RUN if [ -z "$C_COMPILER" ]; then echo "Missing C_COMPILER --build-arg" && exit 
 ENV CC="$C_COMPILER"
 ENV CXX="$CXX_COMPILER"
 
+# Install build dependencies that are too heavy to be built on GHA arm64 emulated runners using Conan
+RUN apt-get update \
+&& apt-get install -y bison flex
+
+RUN printf '[platform_tool_requires]\nbison/%s\nflex/%s\n' \
+    "$(bison --version | head -n 1 | rev | cut -d ' ' -f 1 | rev)" \
+    "$(flex --version | head -n 1 | rev | cut -f 1 | rev)" | \
+    tee -a "$CONAN_DEFAULT_PROFILE_PATH"
+
+RUN printf '[replace_tool_requires]\nbison/*: bison/%s\nflex/*: flex/%s\n' \
+    "$(bison --version | head -n 1 | rev | cut -d ' ' -f 1 | rev)" \
+    "$(flex --version  | head -n 1 | rev | cut -d ' ' -f 1 | rev)" | \
+    tee -a "$CONAN_DEFAULT_PROFILE_PATH"
+
 # Install b2 using Conan
 RUN printf '[requires]\nb2/5.2.1\n[options]\nb2*:toolset=%s' \
            "$(basename "$(which "$CC")")" | cut -f 1 -d - > /tmp/conanfile.txt
@@ -55,7 +69,7 @@ RUN conan install /tmp/conanfile.txt                 \
 RUN mkdir -p "$src_dir"
 
 COPY conanfile.py "$src_dir"
-RUN conan install "$src_dir/conanfile.py"       \
+RUN conan install "$src_dir/conanfile.py"        \
              --build=missing                     \
              -pr:b="$CONAN_DEFAULT_PROFILE_PATH" \
              -pr:h="$CONAN_DEFAULT_PROFILE_PATH" \


### PR DESCRIPTION
For some odd reason, on arm, clang-19 (19.1.4 (++20241112103540+d174e2a55389-1~exp1~20241112103634.61) to be precise) from Ubuntu 24.04 is very slow.
Either that or QEMU arm64 emulation got particularly slow overnight.
I don't think there's much we can do for the time being.
Hopefully, GitHub will make the arm64 runners available to the public in the near future so that we don't have to deal with arch emulation any longer.