### PR TITLE
[fix]: Add a build knob to disable the use of pidfd_open()

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -150,6 +150,7 @@ endif()
 
 option(BUILD_SHARED_LIBS "Build shared library" OFF)
 option(NCHG_ENABLE_TESTING "Build unit tests" ON)
+option(NCHG_USE_PIDFD_OPEN "Use pidfd_open() when available" ON)
 
 add_subdirectory(src)
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -94,6 +94,7 @@ RUN cmake -DCMAKE_BUILD_TYPE=Release            \
           -DENABLE_DEVELOPER_MODE=OFF           \
           -DCMAKE_INSTALL_PREFIX="$staging_dir" \
           -DNCHG_ENABLE_TESTING=OFF             \
+          -DNCHG_USE_PIDFD_OPEN=OFF             \
           -DGIT_RETRIEVED_STATE=true            \
           -DGIT_TAG="$GIT_TAG"                  \
           -DGIT_IS_DIRTY="$GIT_IS_DIRTY"        \

--- a/src/nchg/CMakeLists.txt
+++ b/src/nchg/CMakeLists.txt
@@ -66,7 +66,12 @@ target_link_libraries(
     Threads::Threads
 )
 
-target_compile_definitions(NCHG PRIVATE SPDLOG_ACTIVE_LEVEL=SPDLOG_LEVEL_TRACE)
+target_compile_definitions(
+  NCHG
+  PRIVATE
+    SPDLOG_ACTIVE_LEVEL=SPDLOG_LEVEL_TRACE
+    "$<$<NOT:$<BOOL:${NCHG_USE_PIDFD_OPEN}>>:BOOST_PROCESS_V2_DISABLE_PIDFD_OPEN>"
+)
 
 include(GNUInstallDirs)
 


### PR DESCRIPTION
This is mostly needed to ensure that the binaries produced by compiling NCHG on Linux systems running kernel 5.14 or newer are able to run also on systems with older kernels.

This is especially important for the containerized version of NCHG, as the Docker images are usually built using cloud/dev machines running recent versions of the Linux kernel, while the image itself could be deployed on systems running dated versions of the Linux kernel.